### PR TITLE
[LostWorldQuickBoot] Allow booting to dev menu

### DIFF
--- a/Source/LostWorldQuickBoot/Mod.cpp
+++ b/Source/LostWorldQuickBoot/Mod.cpp
@@ -2,7 +2,7 @@
 
 std::string stageId;
 
-enum Type { TYPE_NORMAL, TYPE_TO_TITLE, TYPE_TO_E3_TITLE, TYPE_TO_MULTISELECT, TYPE_TO_BATTLE, TYPE_TO_WORLD_MAP, TYPE_TO_STAGE, TYPE_TO_MINIGAME } type;
+enum Type { TYPE_NORMAL, TYPE_TO_TITLE, TYPE_TO_E3_TITLE, TYPE_TO_MULTISELECT, TYPE_TO_BATTLE, TYPE_TO_WORLD_MAP, TYPE_TO_STAGE, TYPE_TO_MINIGAME, TYPE_TO_DEVMENU } type;
 
 enum ExitType { EXIT_TYPE_NORMAL, EXIT_TYPE_RELOAD } exitType;
 
@@ -54,6 +54,10 @@ HOOK(void*, __fastcall, SaveInitState, ASLR(0x910690), void* gameSequence, void*
 
 		case TYPE_TO_MINIGAME:
 			*(uint32_t*)((uint32_t)gameSequence + 80) = ASLR(0x9108D0);
+			break;
+
+		case TYPE_TO_DEVMENU:
+			*(uint32_t*)((uint32_t)gameSequence + 80) = ASLR(0x9101A0);
 			break;
 		}
 	}

--- a/UpdateServer/LostWorldQuickBoot/QuickBoot.json
+++ b/UpdateServer/LostWorldQuickBoot/QuickBoot.json
@@ -35,35 +35,39 @@
     "Type": [
 	  {
         "DisplayName": "Normal",
-        "Value": "0",
+        "Value": "0"
       },
       {
         "DisplayName": "Title menu",
-        "Value": "1",
+        "Value": "1"
       },
       {
         "DisplayName": "E3 title menu",
-        "Value": "2",
+        "Value": "2"
       },
       {
         "DisplayName": "Multiplayer menu",
-        "Value": "3",
+        "Value": "3"
       },
       {
         "DisplayName": "Multiplayer battle",
-        "Value": "4",
+        "Value": "4"
       },
       {
         "DisplayName": "World map",
-        "Value": "5",
+        "Value": "5"
       },
       {
         "DisplayName": "Stage",
-        "Value": "6",
+        "Value": "6"
       },
       {
         "DisplayName": "Minigame",
-        "Value": "7",
+        "Value": "7"
+      },
+      {
+        "DisplayName": "Developer Menu",
+        "Value": "8"
       }
     ],
 	"ExitType": [


### PR DESCRIPTION
This PR allows LostWorldQuickBoot to boot into StateDevMenu when type is set to 8.